### PR TITLE
Create CNAME file for GitHub Pages

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+cloudevents.io


### PR DESCRIPTION
Working on a personal site, I discovered that Travis doesn't push this file, which is needed by GitHub Pages. Without this, the GitHub Pages custom domain has to be added manually after each push. This file should copy to the root of the cloudevents.github.io repo.