### PR TITLE
Fix typo in Oracle Cloud integration URL

### DIFF
--- a/data/integrations.yaml
+++ b/data/integrations.yaml
@@ -26,5 +26,5 @@
 - name: Oracle Cloud
   description: |
     The Oracle Cloud Infrastructure Events service implements CloudEvents
-  url: https://blogs.oracle.com/cloud-infrastructure/track-and-react-to-cloud-native-event
+  url: https://blogs.oracle.com/cloud-infrastructure/track-and-react-to-cloud-native-events
   logo: oracle.png


### PR DESCRIPTION
Hi all,

A small fix to correct a typo in the Oracle Cloud OCI support blog post link URL on cloudevents.io

Thank you very much!

Signed-off-by: Gerald Venzl <gerald.venzl@oracle.com>