### PR TITLE
fix broken primer link after re-org in spec repo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -70,7 +70,7 @@ weight = 1
 
 [[menus.main]]
 name = "Primer"
-url = "https://github.com/cloudevents/spec/blob/master/primer.md"
+url = "https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md"
 weight = 2
 
 [[menus.main]]


### PR DESCRIPTION
Primer link is broken after reorganization of files in [spec ](https://github.com/cloudevents/spec) repo.