### PR TITLE
fix: update logo widths

### DIFF
--- a/layouts/partials/home/integrations.html
+++ b/layouts/partials/home/integrations.html
@@ -18,7 +18,7 @@
           <div class="card-content">
             <div class="columns is-vcentered">
               <div class="column is-one-quarter">
-                <figure class="image is-64x64">
+                <figure class="image">
                   <img src="{{ $logo }}" alt="{{ $alt }}">
                 </figure>
               </div>


### PR DESCRIPTION
This PR makes the integration logos width dynamic rather than fixed to prevent poor overlapping of logos. It's noticeable on vertical screens.

It's often best to let images dynamically size in general.

See screenshots. Tested locally.

---

### BEFORE

<img width="983" alt="Screen Shot 2021-12-10 at 10 43 53" src="https://user-images.githubusercontent.com/744973/145626244-f0eaf171-2653-4739-a7e7-38a6339652a1.png">

### AFTER

<img width="985" alt="Screen Shot 2021-12-10 at 10 44 08" src="https://user-images.githubusercontent.com/744973/145626318-af261596-4830-4817-9b41-ecc87a9f26fa.png">

R: @duglin 