### PR TITLE
Fixing adoption urls on website

### DIFF
--- a/data/en/integrations.yaml
+++ b/data/en/integrations.yaml
@@ -157,12 +157,12 @@
 - name: TriggerMesh
   description: |
     TriggerMesh makes use of CloudEvents in all its event sources and targets to build application flows
-  url: https://www.triggermesh.com
+  url: https://github.com/triggermesh/triggermesh
   logo: triggermesh.png
 - name: VMware Event Broker Appliance
   description: |
     VMware Event Broker Appliance (VEBA) publishes CloudEvents for changes in a vSphere cluster
-  url: https://vmweventbroker.io/
+  url: https://github.com/vmware-archive/vcenter-event-broker-appliance
   logo: veba.png
 - name: Voxie
   url: https://www.voxie.com

--- a/data/zh-cn/integrations.yaml
+++ b/data/zh-cn/integrations.yaml
@@ -106,12 +106,12 @@
 - name: TriggerMesh
   description: |
     TriggerMesh 在其所有事件源和目标中使用 CloudEvents 来构建应用程序流。
-  url: https://www.triggermesh.com
+  url: https://github.com/triggermesh/triggermesh
   logo: triggermesh.png
 - name: VMware Event Broker Appliance
   description: |
     VMware Event Broker Appliance (VEBA) 针对 vSphere 集群中的更改发布 CloudEvents。
-  url: https://vmweventbroker.io/
+  url: https://github.com/vmware-archive/vcenter-event-broker-appliance
   logo: veba.png
 - name: wasmCloud
   url: https://wasmcloud.dev


### PR DESCRIPTION
I was checking out the website for CloudEvents and happened to click on the link for the "[VMware Event Broker Appliance](https://vmweventbroker.io/)" project in the adopters section. It seems that this project is archived and they have since surrendered this domain. It seems to have unfortunately been taken up by a betting and gambling company.

This PR fixes this by pointing to the archived project on Github (didn't feel it was my call to remove it from the page entirely), whilst also fixing the link for triggermesh, another archived project which is linked to a dead url.

<img width="1206" height="867" alt="image" src="https://github.com/user-attachments/assets/ac87fe7b-f915-469d-89ca-5b9563f96f2c" />
