### PR TITLE
Fix Accessibility Violations for Social Media Links

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -74,7 +74,7 @@
 
         <div class="buttons is-radiusless">
           {{ range $social }}
-          <a class="button is-small is-{{ .color }} is-radiusless" href="{{ .url }}" target="_blank">
+          <a class="button is-small is-{{ .color }} is-radiusless" href="{{ .url }}" target="_blank" aria-label="{{ .tag | title }}">
             <span class="icon">
               <i class="fab fa-{{ .tag }}"></i>
             </span>


### PR DESCRIPTION
## Summary
This PR resolves 2 accessibility violations detected by the IBM Equal Access Accessibility Checker in the footer social media links. The fix adds accessible names to icon-only links to ensure screen reader users can identify the purpose of each social media link.

## Problem

<img width="2560" height="919" alt="image" src="https://github.com/user-attachments/assets/5fc0301a-ba8a-44cb-ad06-6079e830863f" />

The IBM A11Y Checker identified the following issues: `Hyperlinks Without Accessible Names (2 violations)`

- Elements: Social media links in the footer (GitHub and Twitter)
- Issue: Links contain only Font Awesome icons (`<i class="fab fa-{{ .tag }}">`) without text or ARIA labels
- Rule Violated: Hyperlinks must have an accessible name for their purpose
- Impact: Screen reader users cannot identify which social media platform each link leads to
- WCAG Reference: WCAG Success Criterion 2.4.4 (Link Purpose in Context)

## Solution
Added an aria-label attribute that dynamically generates accessible names from the social media tag.

``` html
<a class="button is-small is-{{ .color }} is-radiusless" href="{{ .url }}" target="_blank" aria-label="{{ .tag | title }}">
  <span class="icon">
    <i class="fab fa-{{ .tag }}"></i>
  </span>
</a>
```
