### PR TITLE
fix: remove CNCF announcement banner embed

### DIFF
--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -1,5 +1,4 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.slim.min.js" integrity="sha256-pasqAKBDmFT4eHoN2ndd6lN370kFiGUFyTiUHWhU7k8=" crossorigin="anonymous"></script>
-<script src="https://www.cncf.io/wp-content/themes/cncf-twenty-two/source/js/on-demand/hello-bar-embed.js" defer></script>
 <script>
   $(".navbar-burger").click(function() {
     $(".navbar-burger").toggleClass("is-active");


### PR DESCRIPTION
Fixes: https://github.com/cloudevents/cloudevents-web/issues/96

## Summary

- remove the external CNCF hello-bar embed added in #95

## Testing

- `npm install`
- `/tmp/ce-hugo-060/hugo --minify`